### PR TITLE
Default model should be pre-selected in model selection dropdown for new user signups

### DIFF
--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -40,7 +40,9 @@ const ChatContent = ({ threadId: routeThreadId, folderId }: ChatProps) => {
 
     useMemo(() => {
         if (!selectedModel && MODELS_SHARED.length > 0) {
-            setSelectedModel(MODELS_SHARED[0].id)
+            // Set gemini-2.5-flash as the default model for new users (built-in, no API key required)
+            const defaultModel = MODELS_SHARED.find((m) => m.id === "gemini-2.5-flash")
+            setSelectedModel(defaultModel ? defaultModel.id : MODELS_SHARED[0].id)
         }
     }, [selectedModel, setSelectedModel])
 

--- a/src/components/model-selector.tsx
+++ b/src/components/model-selector.tsx
@@ -229,6 +229,21 @@ export function ModelSelector({
 
     const isMobile = useIsMobile()
 
+    // Auto-select first available model if the current selection is not available
+    React.useEffect(() => {
+        if (!selectedModelData && availableModels.length > 0) {
+            // Find a built-in model first (one with i3- prefix)
+            const builtInModel = availableModels.find((model) => {
+                const sharedModel = model as SharedModel
+                return sharedModel.adapters?.some((adapter) => adapter.startsWith("i3-"))
+            })
+
+            // Use built-in model if found, otherwise use first available
+            const modelToSelect = builtInModel || availableModels[0]
+            onModelChange(modelToSelect.id)
+        }
+    }, [selectedModelData, availableModels, onModelChange])
+
     // React.useEffect(() => {
     //     const down = (e: KeyboardEvent) => {
     //         if (e.key === "k" && (e.metaKey || e.ctrlKey)) {

--- a/src/components/multimodal-input.tsx
+++ b/src/components/multimodal-input.tsx
@@ -713,12 +713,10 @@ export function MultimodalInput({
                                     </div>
                                 </div>
                             )}
-                            {selectedModel && (
-                                <ModelSelector
-                                    selectedModel={selectedModel}
-                                    onModelChange={setSelectedModel}
-                                />
-                            )}
+                            <ModelSelector
+                                selectedModel={selectedModel || ""}
+                                onModelChange={setSelectedModel}
+                            />
 
                             {isImageModel ? (
                                 <AspectRatioSelector selectedModel={selectedModel} />

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -2,7 +2,7 @@ import { ABILITIES } from "@/convex/lib/toolkit"
 import { z } from "zod"
 
 const AIConfigSchema = z.object({
-    selectedModel: z.string().nullable(),
+    selectedModel: z.string().nullable().default("gemini-2.5-flash"),
     enabledTools: z
         .array(z.enum(ABILITIES as readonly ["web_search", "supermemory", "mcp"]))
         .default(["web_search"]),
@@ -25,7 +25,7 @@ const safeRemoveItem = (key: string): void => {
 export const loadAIConfig = (): AIConfig => {
     if (typeof window === "undefined")
         return {
-            selectedModel: null,
+            selectedModel: "gemini-2.5-flash", // Default built-in model for new users
             enabledTools: ["web_search"],
             selectedImageSize: "1:1",
             reasoningEffort: "medium"
@@ -33,7 +33,7 @@ export const loadAIConfig = (): AIConfig => {
     const stored = localStorage.getItem(AI_CONFIG_KEY)
     if (!stored) {
         return {
-            selectedModel: null,
+            selectedModel: "gemini-2.5-flash", // Default built-in model for new users
             enabledTools: ["web_search"],
             selectedImageSize: "1:1",
             reasoningEffort: "medium"
@@ -56,7 +56,7 @@ export const loadAIConfig = (): AIConfig => {
     } catch {
         safeRemoveItem(AI_CONFIG_KEY)
         return {
-            selectedModel: null,
+            selectedModel: "gemini-2.5-flash", // Default built-in model for new users
             enabledTools: ["web_search"],
             selectedImageSize: "1:1",
             reasoningEffort: "medium"


### PR DESCRIPTION
When a user signs up for the first time without any initial configurations, the "model selection" dropdown is displayed with no default model selected. As a result, when the user tries to prompt and test the app immediately after signup, the action fails due to the lack of a selected default model. This creates a confusing and suboptimal user experience.